### PR TITLE
Add alias for Swagger-PHP

### DIFF
--- a/src/de/espend/idea/php/annotation/ApplicationSettings.java
+++ b/src/de/espend/idea/php/annotation/ApplicationSettings.java
@@ -51,6 +51,7 @@ public class ApplicationSettings implements PersistentStateComponent<Application
         options.add(new UseAliasOption("Gedmo\\Mapping\\Annotation", "Gedmo", true));
         options.add(new UseAliasOption("Vich\\UploaderBundle\\Mapping\\Annotation", "Vich", true));
         options.add(new UseAliasOption("FOS\\RestBundle\\Controller\\Annotations", "Rest", true));
+        options.add(new UseAliasOption("Swagger\\Annotations", "SWG", true));
 
         return options;
     }


### PR DESCRIPTION
This PR adds the recommended alias for annotations from the [Swagger-PHP](https://github.com/zircote/swagger-php) library.