### PR TITLE
Use ORM alias for embedded classes

### DIFF
--- a/src/main/java/de/espend/idea/php/annotation/doctrine/action/DoctrineEmbeddedClassAnnotationGenerateAction.java
+++ b/src/main/java/de/espend/idea/php/annotation/doctrine/action/DoctrineEmbeddedClassAnnotationGenerateAction.java
@@ -25,7 +25,7 @@ public class DoctrineEmbeddedClassAnnotationGenerateAction extends DoctrineClass
         // insert ORM alias
         PhpPsiElement scopeForUseOperator = PhpCodeInsightUtil.findScopeForUseOperator(phpClass.getFirstChild());
         if(scopeForUseOperator != null) {
-            PhpElementsUtil.insertUseIfNecessary(scopeForUseOperator, DoctrineUtil.DOCTRINE_ORM_MAPPING, "Embedded");
+            PhpElementsUtil.insertUseIfNecessary(scopeForUseOperator, DoctrineUtil.DOCTRINE_ORM_MAPPING, "ORM");
             PsiDocumentManager.getInstance(psiFile.getProject()).doPostponedOperationsAndUnblockDocument(editor.getDocument());
         }
 


### PR DESCRIPTION
To be consistent with other parts. For now it generates:

```php
use Doctrine\ORM\Mapping as Embedded;

/**
 * @Embedded\Embedded
 */
class UserIdentity
{
}
```

IMHO it is better use `ORM` alias everywhere.