### PR TITLE
Register identifier reference on doc token instead of parent doc tag

### DIFF
--- a/src/main/java/de/espend/idea/php/annotation/reference/DocTagNameAnnotationReferenceContributor.java
+++ b/src/main/java/de/espend/idea/php/annotation/reference/DocTagNameAnnotationReferenceContributor.java
@@ -58,7 +58,8 @@ public class DocTagNameAnnotationReferenceContributor extends PsiReferenceContri
             public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
                 String text = element.getText();
                 if (StringUtils.isBlank(text)) return PsiReference.EMPTY_ARRAY;
-                if (!PhpDocUtil.isDocStaticElement(element.getNextSibling())) return PsiReference.EMPTY_ARRAY;
+                PsiElement nextSibling = element.getNextSibling();
+                if (nextSibling == null || !PhpDocUtil.isDocStaticElement(nextSibling)) return PsiReference.EMPTY_ARRAY;
 
                 PsiElement docTag = PhpPsiUtil.getParentByCondition(element, PhpDocTag.INSTANCEOF);
                 if (docTag == null) return PsiReference.EMPTY_ARRAY;
@@ -66,7 +67,7 @@ public class DocTagNameAnnotationReferenceContributor extends PsiReferenceContri
                 PsiElement attributes = PhpPsiUtil.getChildOfType(docTag, PhpDocElementTypes.phpDocAttributeList);
                 if (attributes == null) return PsiReference.EMPTY_ARRAY;
 
-                PhpClass phpClass = PhpElementsUtil.getClassByContext(element.getNextSibling(), text);
+                PhpClass phpClass = PhpElementsUtil.getClassByContext(nextSibling, text);
                 if (phpClass == null) return PsiReference.EMPTY_ARRAY;
 
                 return new PsiReference[]{new PhpDocIdentifierReference(element, phpClass.getFQN())};

--- a/src/main/java/de/espend/idea/php/annotation/reference/DocTagNameAnnotationReferenceContributor.java
+++ b/src/main/java/de/espend/idea/php/annotation/reference/DocTagNameAnnotationReferenceContributor.java
@@ -175,23 +175,18 @@ public class DocTagNameAnnotationReferenceContributor extends PsiReferenceContri
      * Adds support for references of "@Foobar(name=Fo<caret>oBar::Const)"
      */
     private static class PhpDocIdentifierReference extends PsiReferenceBase<PsiElement> {
-
-        @NotNull
-        private final PsiElement element;
-
         @NotNull
         private final String fqn;
 
         PhpDocIdentifierReference(@NotNull PsiElement element, @NotNull String fqn) {
             super(element);
-            this.element = element;
             this.fqn = fqn;
         }
 
         @NotNull
         @Override
         public TextRange getRangeInElement() {
-            return TextRange.create(0, element.getTextLength());
+            return TextRange.create(0, myElement.getTextLength());
         }
 
         @Nullable
@@ -216,13 +211,13 @@ public class DocTagNameAnnotationReferenceContributor extends PsiReferenceContri
                 return false;
             }
 
-            PsiElement namespace = element.getPrevSibling();
+            PsiElement namespace = myElement.getPrevSibling();
             if(PhpPsiUtil.isOfType(namespace, PhpDocTokenTypes.DOC_NAMESPACE)) {
                 // @TODO: namespace not supported
                 return false;
             }
 
-            String classByContext = PhpElementsUtil.getFqnForClassNameByContext(element, text);
+            String classByContext = PhpElementsUtil.getFqnForClassNameByContext(myElement, text);
             if(classByContext != null) {
                 return StringUtils.stripStart(((PhpNamedElement) psiElement).getFQN(), "\\")
                     .equalsIgnoreCase(StringUtils.stripStart(fqn, "\\"));


### PR DESCRIPTION
Hello!

There is an implicit contract in `com.intellij.psi.PsiReferenceProvider` which stands for the rule, that for any provided reference via provider  result of `PsiReference#getElement` should be equal to the first parameter of the `com.intellij.psi.PsiReferenceProvider#getReferencesByElement` (basically clients have to provide same element as underlying element of the reference). 

This contract exists to keep consistency in many places and recently it was [enforced](https://github.com/JetBrains/intellij-community/commit/4c85d6a7b9728d39efa68d178e6e875c2f4a5d40), so now any client which broke the contract will start to get many exceptions in different places. This change is not in the public build yet, error was caught by our internal tests).

This PR proposes to fix the problem by registering `PhpDocIdentifierReference` directly via `PhpDocToken`. The logic should stay the same, but could you please test and verify that change is not actually breaking your logic? 