### PR TITLE
Insert Embeddable instead of Embedded annotation for class

### DIFF
--- a/src/main/java/de/espend/idea/php/annotation/doctrine/action/DoctrineEmbeddedClassAnnotationGenerateAction.java
+++ b/src/main/java/de/espend/idea/php/annotation/doctrine/action/DoctrineEmbeddedClassAnnotationGenerateAction.java
@@ -18,7 +18,7 @@ public class DoctrineEmbeddedClassAnnotationGenerateAction extends DoctrineClass
     @NotNull
     @Override
     protected String supportedClass() {
-        return "Doctrine\\ORM\\Mapping\\Embedded";
+        return "Doctrine\\ORM\\Mapping\\Embeddable";
     }
 
     protected void execute(@NotNull Editor editor, @NotNull PhpClass phpClass, @NotNull PsiFile psiFile) {


### PR DESCRIPTION
According to the [documentation ](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/tutorials/embeddables.html) class should have `Embeddable` annotation, not the `Embedded`