### PR TITLE
Corresponding bracket highlighting in Annotations

### DIFF
--- a/src/main/java/de/espend/idea/php/annotation/ApplicationSettings.java
+++ b/src/main/java/de/espend/idea/php/annotation/ApplicationSettings.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 public class ApplicationSettings implements PersistentStateComponent<ApplicationSettings> {
 
     public boolean appendRoundBracket = true;
+    public boolean activateBracketHighlighting = true;
 
     public List<UseAliasOption> useAliasOptions = new ArrayList<>();
 

--- a/src/main/java/de/espend/idea/php/annotation/annotator/AnnotationCaretListener.java
+++ b/src/main/java/de/espend/idea/php/annotation/annotator/AnnotationCaretListener.java
@@ -1,0 +1,40 @@
+package de.espend.idea.php.annotation.annotator;
+
+import com.intellij.openapi.editor.EditorFactory;
+import com.intellij.openapi.editor.event.CaretEvent;
+import com.intellij.openapi.editor.event.CaretListener;
+import com.intellij.openapi.editor.event.EditorEventMulticaster;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.FileContentUtil;
+import com.jetbrains.php.lang.psi.PhpFile;
+import de.espend.idea.php.annotation.ApplicationSettings;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+
+public class AnnotationCaretListener implements StartupActivity, DumbAware {
+    @Override
+    public void runActivity(@NotNull Project project) {
+        final EditorEventMulticaster eventMulticaster = EditorFactory.getInstance().getEventMulticaster();
+        final PsiDocumentManager psiDocumentManager = PsiDocumentManager.getInstance(project);
+        if (ApplicationSettings.getInstance().activateBracketHighlighting) {
+            eventMulticaster.addCaretListener(new CaretListener() {
+                @Override
+                public void caretPositionChanged(@NotNull CaretEvent e) {
+                    final PsiFile psiFile = psiDocumentManager.getPsiFile(e.getEditor().getDocument());
+                    if (psiFile instanceof PhpFile) {
+                        int offset = e.getEditor().logicalPositionToOffset(e.getNewPosition());
+                        if (BracketHighlighter.getBracketPositionNextToOffset(offset, psiFile.getText()) == -1)
+                            return;
+
+                        FileContentUtil.reparseFiles(project, Collections.singletonList(psiFile.getVirtualFile()), true);
+                    }
+                }
+            }, project);
+        }
+    }
+}

--- a/src/main/java/de/espend/idea/php/annotation/annotator/AnnotationDocTagAnnotator.java
+++ b/src/main/java/de/espend/idea/php/annotation/annotator/AnnotationDocTagAnnotator.java
@@ -5,6 +5,7 @@ import com.intellij.lang.annotation.Annotator;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocTag;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
+import de.espend.idea.php.annotation.ApplicationSettings;
 import de.espend.idea.php.annotation.extension.PhpAnnotationDocTagAnnotator;
 import de.espend.idea.php.annotation.extension.parameter.PhpAnnotationDocTagAnnotatorParameter;
 import de.espend.idea.php.annotation.util.AnnotationUtil;
@@ -45,6 +46,10 @@ public class AnnotationDocTagAnnotator implements Annotator {
         PhpAnnotationDocTagAnnotatorParameter parameter = new PhpAnnotationDocTagAnnotatorParameter(phpClass, (PhpDocTag) psiElement, holder);
         for(PhpAnnotationDocTagAnnotator annotator: AnnotationUtil.EP_DOC_TAG_ANNOTATOR.getExtensions()) {
             annotator.annotate(parameter);
+        }
+
+        if (ApplicationSettings.getInstance().activateBracketHighlighting) {
+            BracketHighlighter.highlightCaretBracketPair(psiElement, holder);
         }
     }
 }

--- a/src/main/java/de/espend/idea/php/annotation/annotator/BracketHighlighter.java
+++ b/src/main/java/de/espend/idea/php/annotation/annotator/BracketHighlighter.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 public class BracketHighlighter {
     private static final char[][] BRACKET_PAIRS = {
@@ -116,16 +117,12 @@ public class BracketHighlighter {
 
     private static int getCaretOffsetInElement(PsiElement element)
     {
-        Editor[] editor = new Editor[1];
-        ApplicationManager.getApplication()
-                .invokeLater( () -> editor[0] = FileEditorManager.getInstance(element.getProject()).getSelectedTextEditor());
-        try {
-            Thread.sleep(100);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        Editor editor = FileEditorManager.getInstance(element.getProject()).getSelectedTextEditor();
 
-        return editor[0].getCaretModel().getOffset() - element.getTextRange().getStartOffset();
+        if (editor == null)
+            return -1;
+
+        return editor.getCaretModel().getOffset() - element.getTextRange().getStartOffset();
     }
 
     public static int getBracketPositionNextToOffset(int offset, String text)

--- a/src/main/java/de/espend/idea/php/annotation/annotator/BracketHighlighter.java
+++ b/src/main/java/de/espend/idea/php/annotation/annotator/BracketHighlighter.java
@@ -1,0 +1,169 @@
+package de.espend.idea.php.annotation.annotator;
+
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.markup.EffectType;
+import com.intellij.openapi.editor.markup.TextAttributes;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.ui.JBColor;
+import groovy.lang.Tuple2;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class BracketHighlighter {
+    private static final char[][] BRACKET_PAIRS = {
+            {'(', ')'},
+            {'{', '}'},
+    };
+
+    public static void highlightCaretBracketPair(@NotNull PsiElement psiElement, @NotNull AnnotationHolder holder)
+    {
+        int caretOffset = getCaretOffsetInElement(psiElement);
+        String text = psiElement.getText();
+
+        caretOffset = getBracketPositionNextToOffset(caretOffset, text);
+        if (caretOffset == -1)
+        {
+            return;
+        }
+
+        List<Tuple2<Integer, Integer>> bracketPairs = findBracketPairs(text);
+
+        annotate(holder, caretOffset + psiElement.getTextOffset());
+        annotate(holder, getComplementBracketPosition(caretOffset, bracketPairs) + psiElement.getTextOffset());
+    }
+
+    private static void annotate(AnnotationHolder holder, int startPos)
+    {
+        TextAttributes attr = new TextAttributes(null, null, JBColor.orange, EffectType.BOXED, 0);
+        holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                .range(new TextRange(startPos, startPos + 1))
+                .enforcedTextAttributes(attr)
+                .create();
+    }
+
+    private static List<Tuple2<Integer, Integer>> findBracketPairs(String text)
+    {
+        List<Tuple2<Integer, Integer>> bracketPairs = new LinkedList<>();
+
+        for(int i = 0, n = text.length() ; i < n ; i++) {
+            char c = text.charAt(i);
+
+            if (isOpeningBracketChar(c)) {
+                int closingPos = findClosingBracketPosition(i, c, text, bracketPairs);
+                if (closingPos == 0)
+                    return bracketPairs;
+
+                bracketPairs.add(new Tuple2<>(i, closingPos));
+
+                i = closingPos;
+            }
+        }
+
+        return bracketPairs;
+    }
+
+    private static int findClosingBracketPosition(int openingPos, char openingChar, String text, List<Tuple2<Integer, Integer>> bracketPairs)
+    {
+        char closingChar = getMatchingClosingBracketChar(openingChar);
+
+        for(int i = openingPos + 1, n = text.length() ; i < n ; i++) {
+            char c = text.charAt(i);
+            if (isOpeningBracketChar(c)) {
+                int closingPos = findClosingBracketPosition(i, c, text, bracketPairs);
+                if (closingPos == 0)
+                    return 0;
+
+                bracketPairs.add(new Tuple2<>(i, closingPos));
+
+                i = closingPos;
+
+                continue;
+            }
+            if (c == closingChar) {
+                return i;
+            }
+        }
+
+        return 0;
+    }
+
+    private static char getMatchingClosingBracketChar(char openingChar)
+    {
+        for (char[] ca : BRACKET_PAIRS) {
+            if (openingChar == ca[0])
+                return ca[1];
+        }
+
+        return ' ';
+    }
+
+    private static int getComplementBracketPosition(int position, List<Tuple2<Integer, Integer>> bracketPairs)
+    {
+        for (Tuple2<Integer, Integer> pair : bracketPairs) {
+            if (pair.getFirst() == position) return pair.getSecond();
+            if (pair.getSecond() == position) return pair.getFirst();
+        }
+
+        return 0;
+    }
+
+    private static int getCaretOffsetInElement(PsiElement element)
+    {
+        Editor[] editor = new Editor[1];
+        ApplicationManager.getApplication()
+                .invokeLater( () -> editor[0] = FileEditorManager.getInstance(element.getProject()).getSelectedTextEditor());
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        return editor[0].getCaretModel().getOffset() - element.getTextRange().getStartOffset();
+    }
+
+    public static int getBracketPositionNextToOffset(int offset, String text)
+    {
+        if (text.length() <= offset || offset < 0) return -1;
+
+        char c = text.charAt(offset);
+        if (!isOpeningBracketChar(c) && !isClosingBracketChar(c))
+        {
+            offset--;
+            c = text.charAt(offset);
+
+            if (!isOpeningBracketChar(c) && !isClosingBracketChar(c))
+            {
+                return -1;
+            }
+        }
+
+        return offset;
+    }
+
+    private static boolean isOpeningBracketChar(char c)
+    {
+        for (char[] ca : BRACKET_PAIRS) {
+            if (c == ca[0])
+                return true;
+        }
+
+        return false;
+    }
+
+    private static boolean isClosingBracketChar(char c)
+    {
+        for (char[] ca : BRACKET_PAIRS) {
+            if (c == ca[1])
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/de/espend/idea/php/annotation/ui/SettingsForm.form
+++ b/src/main/java/de/espend/idea/php/annotation/ui/SettingsForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="de.espend.idea.php.annotation.ui.SettingsForm">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -18,7 +18,7 @@
       </component>
       <vspacer id="eeb64">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="959af" class="javax.swing.JCheckBox" binding="appendRoundBracket">
@@ -60,6 +60,14 @@
           </hspacer>
         </children>
       </grid>
+      <component id="80733" class="javax.swing.JCheckBox" binding="activateBracketHighlighting">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Activate bracket highlighting"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/src/main/java/de/espend/idea/php/annotation/ui/SettingsForm.java
+++ b/src/main/java/de/espend/idea/php/annotation/ui/SettingsForm.java
@@ -16,6 +16,7 @@ import java.awt.event.MouseEvent;
  */
 public class SettingsForm implements Configurable {
     private JCheckBox appendRoundBracket;
+    private JCheckBox activateBracketHighlighting;
     private JPanel panel;
     private JButton buttonCleanIndex;
 
@@ -49,14 +50,17 @@ public class SettingsForm implements Configurable {
 
     @Override
     public boolean isModified() {
+        ApplicationSettings settings = ApplicationSettings.getInstance();
         return
-            !appendRoundBracket.isSelected() == ApplicationSettings.getInstance().appendRoundBracket
-        ;
+            !appendRoundBracket.isSelected() == settings.appendRoundBracket ||
+                    !activateBracketHighlighting.isSelected() == settings.activateBracketHighlighting;
     }
 
     @Override
     public void apply() throws ConfigurationException {
-        ApplicationSettings.getInstance().appendRoundBracket = appendRoundBracket.isSelected();
+        ApplicationSettings settings = ApplicationSettings.getInstance();
+        settings.appendRoundBracket = appendRoundBracket.isSelected();
+        settings.activateBracketHighlighting = activateBracketHighlighting.isSelected();
     }
 
     @Override
@@ -65,7 +69,9 @@ public class SettingsForm implements Configurable {
     }
 
     private void updateUIFromSettings() {
-        appendRoundBracket.setSelected(ApplicationSettings.getInstance().appendRoundBracket);
+        ApplicationSettings settings = ApplicationSettings.getInstance();
+        appendRoundBracket.setSelected(settings.appendRoundBracket);
+        activateBracketHighlighting.setSelected(settings.activateBracketHighlighting);
     }
 
     @Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -83,6 +83,8 @@
 
   <extensions defaultExtensionNs="com.intellij">
 
+      <postStartupActivity implementation="de.espend.idea.php.annotation.annotator.AnnotationCaretListener" />
+
       <projectService serviceImplementation="de.espend.idea.php.annotation.Settings"/>
       <fileBasedIndex implementation="de.espend.idea.php.annotation.AnnotationStubIndex"/>
       <fileBasedIndex implementation="de.espend.idea.php.annotation.AnnotationUsageIndex"/>


### PR DESCRIPTION
I personally love the PHPStorm highlighting off corresponding brackets. Unfortunately this feature does not work for brackets inside PHP Annotations.
I've implemented that feature for annotations.

Unfortunately I did not find a way to perform only specific highlighting on change of the caret position so it maybe is not the perfect solution. But maybe someone knows a better way to do it?