### PR TITLE
#303 migrate intellij gradle plugin to 2.0.0-rc1

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v2
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'adopt'
 
     # Cache Gradle dependencies
@@ -41,7 +41,7 @@ jobs:
       run: chmod +x gradlew
 
     - name: Build with Gradle
-      run: ./gradlew check verifyPlugin buildPlugin
+      run: ./gradlew check test buildPlugin
 
 # enable for multiple build
 #    - name: Build with Gradle for PhpStorm 2022.3.2

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 /php-annotation.jar
 /build
 /.gradle
+.intellijPlatform

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun properties(key: String) = project.findProperty(key).toString()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,12 @@
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun properties(key: String) = project.findProperty(key).toString()
 
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.9.22"
-    id("org.jetbrains.intellij") version "1.17.2"
+    id("org.jetbrains.kotlin.jvm") version "2.0.0"
+    id("org.jetbrains.intellij.platform") version "2.0.0-rc1"
     id("org.jetbrains.changelog") version "1.3.1"
     id("org.jetbrains.qodana") version "0.1.13"
 }
@@ -16,21 +17,36 @@ version = properties("pluginVersion")
 // Configure project's dependencies
 repositories {
     mavenCentral()
+
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 dependencies {
-    implementation("org.junit.jupiter:junit-jupiter:5.8.2")
+    intellijPlatform {
+        val version = providers.gradleProperty("platformVersion")
+        val type = providers.gradleProperty("platformType")
+        create(type, version, useInstaller = false)
+
+        bundledPlugins(properties("platformBundledPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+        plugins(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+
+        testFramework(TestFrameworkType.Plugin.Java)
+    }
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.8.2")
 }
 
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-intellij {
-    pluginName.set(properties("pluginName"))
-    version.set(properties("platformVersion"))
-    type.set(properties("platformType"))
-
-    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+intellijPlatform {
+    pluginConfiguration {
+        name = properties("pluginName")
+    }
+    instrumentCode = false
+    buildSearchableOptions = false
 }
 
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
@@ -64,7 +80,7 @@ tasks {
     }
 
     patchPluginXml {
-        version.set(properties("pluginVersion"))
+        version = properties("pluginVersion")
         sinceBuild.set(properties("pluginSinceBuild"))
         untilBuild.set(properties("pluginUntilBuild"))
         changeNotes.set(file("src/main/resources/META-INF/change-notes.html").readText().replace("<html>", "").replace("</html>", ""))
@@ -79,11 +95,20 @@ tasks {
 
     // Configure UI tests plugin
     // Read more: https://github.com/JetBrains/intellij-ui-test-robot
-    runIdeForUiTests {
-        systemProperty("robot-server.port", "8082")
-        systemProperty("ide.mac.message.dialogs.as.sheets", "false")
-        systemProperty("jb.privacy.policy.text", "<!--999.999-->")
-        systemProperty("jb.consents.confirmation.enabled", "false")
+    intellijPlatformTesting.runIde.registering {
+        task {
+            jvmArgumentProviders += CommandLineArgumentProvider {
+                listOf(
+                    "-Drobot-server.port=8082",
+                    "-Dide.mac.message.dialogs.as.sheets=false",
+                    "-Djb.privacy.policy.text=<!--999.999-->",
+                    "-Djb.consents.confirmation.enabled=false",
+                )
+            }
+        }
+        plugins {
+            robotServerPlugin()
+        }
     }
 
     signPlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,26 +5,27 @@ pluginGroup = de.espend.idea.php.annotation
 pluginName = PHP Annotations
 
 # SemVer format -> https://semver.org
-pluginVersion = 10.0.0
+pluginVersion = 11.0.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 233
+pluginSinceBuild = 242
 pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IU
-platformVersion = 2023.3.4
+platformVersion = 242.20224-EAP-CANDIDATE-SNAPSHOT
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = java,webDeployment,com.jetbrains.php:233.14475.35,de.espend.idea.php.toolbox:6.2.0
+platformBundledPlugins = com.intellij.java,com.jetbrains.plugins.webDeployment
+platformPlugins = com.jetbrains.php:242.20224.112,com.jetbrains.twig:242.20224.112,de.espend.idea.php.toolbox:6.2.0
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
-javaVersion = 17
+javaVersion = 21
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.4
+gradleVersion = 8.8
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.

--- a/src/main/java/de/espend/idea/php/annotation/ApplicationSettings.java
+++ b/src/main/java/de/espend/idea/php/annotation/ApplicationSettings.java
@@ -18,7 +18,7 @@ import java.util.List;
 /**
  * @author Daniel Espendiller <daniel@espendiller.net>
  */
-@State(name = "PhpAnnotationsPlugin", storages = @Storage(file = "$APP_CONFIG$/php-annotations.xml"))
+@State(name = "PhpAnnotationsPlugin", storages = @Storage())
 public class ApplicationSettings implements PersistentStateComponent<ApplicationSettings> {
 
     public boolean appendRoundBracket = true;


### PR DESCRIPTION
We currently have no IU-2024.2 release available for plugin development, but there are also snapshot releases. Plugin authors can rely on them when targeting non-GA 2024.2v. To do this it is needed to switch from Gradle IntelliJ Plugin 1.x to IntelliJ Platform Gradle Plugin 2.0 (currently 2.0.0-rc1)