### PR TITLE
Add alias for Sunrise OpenAPI annotations

### DIFF
--- a/src/main/java/de/espend/idea/php/annotation/ApplicationSettings.java
+++ b/src/main/java/de/espend/idea/php/annotation/ApplicationSettings.java
@@ -59,6 +59,7 @@ public class ApplicationSettings implements PersistentStateComponent<Application
         options.add(new UseAliasOption("OpenApi\\Annotations", "OA", true));
         options.add(new UseAliasOption("OpenApi\\Attributes", "OA", true));
         options.add(new UseAliasOption("Sunrise\\Http\\Router\\Annotation", "Routing", true));
+        options.add(new UseAliasOption("Sunrise\\Symfony\\OpenApi\\Annotation", "OpenApi", true));
 
         for (PhpAnnotationUseAlias extensions: AnnotationUtil.EP_USE_ALIASES.getExtensions()) {
             options.addAll(


### PR DESCRIPTION
Adds a default import alias for `Sunrise\Symfony\OpenApi\Annotation` as `OpenApi`.

This makes annotations like `#[OpenApi\Operation]` available through the existing alias import mechanism.

https://github.com/sunrise-studio-development/symfony-openapi
